### PR TITLE
Remove Wagon dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,26 @@ npm install compose-remote-form
 
 ## Usage
 
-### Just make it AJAX-y already!
+### Setup
 
 ```javascript
 var RemoteForm = require('compose-remote-form')
-
-new RemoteForm({el: document.querySelector('form')})
 ```
 
-### Extending remote forms
+### Add your own ajax event callbacks
 
 More details about each fired "event" below.
 
 ```javascript
-RemoteForm.extend({
+
+// Register single callbacks:
+RemoteForm.on('#formid', 'error', function(body, status, xhr) {
+  console.log('success!', body)
+})
+
+// Register multiple callbacks:
+var formEl = document.querySelector('#formid')
+RemoteForm.on(formEl, {
   beforeSend: function(req){
     console.log('submitting the form...')
   },
@@ -32,7 +38,10 @@ RemoteForm.extend({
   },
   error: function(xhr, status, error){
     console.log('error :(', error)
-  }
+  },
+  complete: function(xhr, status){
+    console.log('complete:', status)
+  },
 })
 ```
 
@@ -54,4 +63,10 @@ Upon success, this is fired with the returned `body`, response `status` and the 
 
 When an error occurs, this event is fired with the original ajax request `xhr` object and the `error` that the ajax library suffered.
 
-It'll be fire in the event of a request not getting through (due to CORS, server down, etc.), a server error (5xx) or a client error (4xx).
+It'll fire in the event of a request not getting through (due to CORS, server down, etc.), a server error (5xx) or a client error (4xx).
+
+### `ajax:complete(xhr, status)`
+
+The `complete` event is fired at the end of the ajax submission lifecycle,
+regardless of success or failure. You might use this event to perform some
+cleanup action no matter the end result of a form submission.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var request = require('superagent')
 var serialize = require('form-serialize')
 var domify = require('domify')
-var event = require('compose-event')
+var Event = require('compose-event')
 var dialog = require('compose-dialog')
 
 var counter = 0
@@ -10,15 +10,15 @@ var DEFAULT_CONTINUE_BUTTON = 'Yes'
 var Form = {
   listen: function(){
 
-    event.on(document, {
+    Event.on(document, {
       submit: this.submit.bind(this),
       'ajax:success': this.success.bind(this),
       'ajax:error': this.error.bind(this),
       'ajax:beforeSend': this.beforeSend.bind(this)
     }, 'form[data-remote]', this.submit)
 
-    event.on(document, 'submit', 'form', this.disableWith)
-    event.on(document, 'click', 'a[data-method], a[data-confirm], button[data-method], button[data-confirm]', this.click.bind(this))
+    Event.on(document, 'submit', 'form', this.disableWith)
+    Event.on(document, 'click', 'a[data-method], a[data-confirm], button[data-method], button[data-confirm]', this.click.bind(this))
   },
 
   submit: function(event){
@@ -41,22 +41,22 @@ var Form = {
     else
       req.set('Accept', '*/*;q=0.5, text/javascript, application/javascript, application/ecmascript, application/x-ecmascript')
 
-    event.fire(form, 'ajax:beforeSend', [req])
+    Event.fire(form, 'ajax:beforeSend', [req])
 
-    req.end(function(error, response) { this.handleResponse(error, response, currentRequest) }.bind(this))
+    req.end(function(error, response) { this.handleResponse(form, error, response, currentRequest) }.bind(this))
 
     return req
   },
 
-  handleResponse: function(error, response, currentRequest){
+  handleResponse: function(form, error, response, currentRequest){
     if (error)
-      event.fire(form, 'ajax:error', [currentRequest.xhr, currentRequest.xhr.status, error])
+      Event.fire(form, 'ajax:error', [currentRequest.xhr, currentRequest.xhr.status, error])
     else if (response.error)
-      event.fire(form, 'ajax:error', [currentRequest.xhr, response.status, response.error])
+      Event.fire(form, 'ajax:error', [currentRequest.xhr, response.status, response.error])
     else
-      event.fire(form, 'ajax:success', [response.body, response.status, currentRequest.xhr])
+      Event.fire(form, 'ajax:success', [response.body, response.status, currentRequest.xhr])
     // This is fired every time.
-    event.fire(form, 'ajax:complete', [currentRequest.xhr, response ? response.status : 0])
+    Event.fire(form, 'ajax:complete', [currentRequest.xhr, response ? response.status : 0])
     delete currentRequest
   },
 
@@ -64,8 +64,8 @@ var Form = {
   success: function(body, status, xhr){},
   error: function(xhr, status, error){},
 
-  disableWith: function(event) {
-    var buttons = event.currentTarget.querySelectorAll('[data-disable-with]')
+  disableWith: function(Event) {
+    var buttons = Event.currentTarget.querySelectorAll('[data-disable-with]')
     Array.prototype.forEach.call(buttons, function(button){
       button.disabled = true
       button.classList.add('disabled')
@@ -134,7 +134,7 @@ var Form = {
 
 }
 
-event.ready(function(){
+Event.ready(function(){
   // Since this is a replacement for Rails UJS, we want to be sure it's not being used.
   if (!window.$ || !$.rails) Form.listen()
 })

--- a/index.js
+++ b/index.js
@@ -1,31 +1,38 @@
-var Wagon = require('wagon')
 var request = require('superagent')
 var serialize = require('form-serialize')
-var bean = require('bean')
+var domify = require('domify')
+var event = require('compose-event')
+var dialog = require('compose-dialog')
 
-module.exports = Wagon.extend({
+var counter = 0
+var DEFAULT_CONTINUE_BUTTON = 'Yes'
 
-  events: {
-    'ajax:success': 'success',
-    'ajax:error': 'error',
-    'ajax:beforeSend': 'beforeSend',
-    'submit': 'submit'
-  },
+var Form = {
+  listen: function(){
 
-  '$': function(){
-    return this.el.querySelector.apply(this.el, arguments) || {}
+    event.on(document, {
+      submit: this.submit.bind(this),
+      'ajax:success': this.success.bind(this),
+      'ajax:error': this.error.bind(this),
+      'ajax:beforeSend': this.beforeSend.bind(this)
+    }, 'form[data-remote]', this.submit)
+
+    event.on(document, 'submit', 'form', this.disableWith)
+    event.on(document, 'click', 'a[data-method], a[data-confirm], button[data-method], button[data-confirm]', this.click.bind(this))
   },
 
   submit: function(event){
+    var form = event.currentTarget
     event.preventDefault()
-    var method = (this.el.dataset.method || this.el.getAttribute('method') || 'get').toLowerCase()
-    var url = this.el.dataset.url || this.el.getAttribute('action')
-    var data = serialize(this.el)
-    var dataType = this.el.dataset.type || undefined // 'form' or 'json'
+
+    var method = (form.dataset.method || form.getAttribute('method') || 'get').toLowerCase()
+    var url = form.dataset.url || form.getAttribute('action')
+    var data = serialize(form)
+    var dataType = form.dataset.type || undefined // 'form' or 'json'
 
     var req;
     if (method === 'delete') method = 'del'
-    this.currentRequest = req = request[method](url)
+    var currentRequest = req = request[method](url)
 
     if (data)
       req.send(data)
@@ -34,27 +41,103 @@ module.exports = Wagon.extend({
     else
       req.set('Accept', '*/*;q=0.5, text/javascript, application/javascript, application/ecmascript, application/x-ecmascript')
 
-    bean.fire(this.el, 'ajax:beforeSend', [req])
+    event.fire(form, 'ajax:beforeSend', [req])
 
-    req.end(this._handleResponse.bind(this))
+    req.end(function(error, response) { this.handleResponse(error, response, currentRequest) }.bind(this))
 
     return req
   },
 
-  _handleResponse: function(error, response){
+  handleResponse: function(error, response, currentRequest){
     if (error)
-      bean.fire(this.el, 'ajax:error', [this.currentRequest.xhr, this.currentRequest.xhr.status, error])
+      event.fire(form, 'ajax:error', [currentRequest.xhr, currentRequest.xhr.status, error])
     else if (response.error)
-      bean.fire(this.el, 'ajax:error', [this.currentRequest.xhr, response.status, response.error])
+      event.fire(form, 'ajax:error', [currentRequest.xhr, response.status, response.error])
     else
-      bean.fire(this.el, 'ajax:success', [response.body, response.status, this.currentRequest.xhr])
+      event.fire(form, 'ajax:success', [response.body, response.status, currentRequest.xhr])
     // This is fired every time.
-    bean.fire(this.el, 'ajax:complete', [this.currentRequest.xhr, response ? response.status : 0])
-    delete this.currentRequest
+    event.fire(form, 'ajax:complete', [currentRequest.xhr, response ? response.status : 0])
+    delete currentRequest
   },
 
   beforeSend: function(req){},
   success: function(body, status, xhr){},
-  error: function(xhr, status, error){}
+  error: function(xhr, status, error){},
 
+  disableWith: function(event) {
+    var buttons = event.currentTarget.querySelectorAll('[data-disable-with]')
+    Array.prototype.forEach.call(buttons, function(button){
+      button.disabled = true
+      button.classList.add('disabled')
+
+      var buttonText = button.dataset.disableWith
+      if (!buttonText || buttonText == '') { buttonText = button.innerHTML }
+
+      // Because dang it all, an elipsis is not three periods.
+      button.innerHTML = buttonText.replace(/\.{3}/, '…')
+    })
+  },
+
+  click: function(event) {
+    event.preventDefault()
+    var el = event.currentTarget
+    var form = null
+
+    if (el.dataset.method) {
+      form = this.buildForm(el)
+      document.body.appendChild(form)
+    }
+
+    if (el.dataset.confirm) {
+      this.confirm(el, form)
+    } else {
+      form.submit()
+    }
+  },
+
+  confirm: function(el, form) {
+    var opts = {
+      title: el.dataset.confirm,
+      message: el.dataset.message || null,
+      continue: el.dataset.continue || DEFAULT_CONTINUE_BUTTON
+    }
+
+    if (el.dataset.method) {
+      opts.submit = '#' + form.getAttribute('id')
+      if (el.dataset.method.toLowerCase() === 'delete') {
+        opts.destructive = true
+        opts.continue = el.dataset.continue || 'Delete'
+      }
+    } else {
+      opts.follow = el.getAttribute('href')
+      opts.destructive = !!el.dataset.destructive
+      opts.submit = el.dataset.submit
+    }
+
+    dialog.show(opts)
+  },
+
+  buildForm: function(el) {
+    var method = el.dataset.method || 'post'
+    var csrfToken = document.querySelector('meta[name=csrf-token]')
+    var csrfParam = document.querySelector('meta[name=csrf-param]')
+
+    var form = domify('<form id="link-'+ (++counter) +'" class="hidden" action="'+el.href+'" method="post"></form>')
+
+    form.appendChild(domify('<input name="_method" value="' + method + '" type="hidden">'))
+
+    if (csrfToken && csrfParam)
+      form.appendChild(domify('<input name="' + csrfParam.getAttribute('content') + '" value="' + csrfToken.getAttribute('content') + '" type="hidden" />'))
+
+    return form
+  }
+
+}
+
+event.ready(function(){
+  // Since this is a replacement for Rails UJS, we want to be sure it's not being used.
+  if (!window.$ || !$.rails) Form.listen()
 })
+
+module.exports = Form
+

--- a/package.json
+++ b/package.json
@@ -10,14 +10,10 @@
     "Jerome Gravel-Niquet"
   ],
   "license": "MIT",
-  "browser": {
-    "wagon": "compose-wagon"
-  },
   "devDependencies": {
     "browserify": "^4.2.3",
     "chai": "^1.9.1",
     "debug": "^1.0.4",
-    "domify": "^1.3.0",
     "lodash": "^2.4.1",
     "mocha": "^1.20.1",
     "mochify": "^0.11.0",
@@ -25,9 +21,10 @@
     "sinon": "^1.10.3"
   },
   "dependencies": {
-    "bean": "^1.0.14",
-    "compose-wagon": "^1.0.0",
+    "compose-event": "^1.0.0",
+    "compose-dialog": "^2.0.0",
     "form-serialize": "^0.3.0",
+    "domify": "^1.3.0",
     "superagent": "^0.18.2"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "compose-remote-form",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Wrap your regular form with moar ajax.",
   "main": "index.js",
   "scripts": {
     "test": "mochify --reporter spec"
   },
   "contributors": [
-    "Jerome Gravel-Niquet"
+    "Jerome Gravel-Niquet",
+    "Brandon Mathis"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "compose-event": "^1.0.0",
-    "compose-dialog": "^2.0.0",
+    "compose-dialog": "^2.0.2",
     "form-serialize": "^0.3.0",
     "domify": "^1.3.0",
     "superagent": "^0.18.2"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,23 +7,30 @@ var request = require('superagent')
 var sinon = require('sinon')
 
 describe('RemoteForm', function(){
-  beforeEach(function(){
+  before(function() {
+    event.fire(document, 'DOMContentLoaded')
     this.formEl = makeHtml(function(){/*
       <form data-remote="true"></form>
     */})
     
+    document.body.appendChild(this.formEl)
+  })
+
+  beforeEach(function(){
     this.beforeSendCb = sinon.spy()
     this.successCb = sinon.spy()
     this.errorCb = sinon.spy()
     this.completeCb = sinon.spy()
     
-    event.on(this.formEl, 'ajax:beforeSend', this.beforeSendCb)
-    event.on(this.formEl, 'ajax:success', this.successCb)
-    event.on(this.formEl, 'ajax:error', this.errorCb)
-    event.on(this.formEl, 'ajax:complete', this.completeCb)
-    
-    document.body.appendChild(this.formEl)
-    event.fire(document, 'DOMContentLoaded')
+    // Typically reset by page loads, this needs to be done manually in testing
+    RemoteForm.resetCallbacks()
+
+    RemoteForm.on(this.formEl, {
+      beforeSend: this.beforeSendCb,
+      success: this.successCb,
+      error: this.errorCb,
+      complete: this.completeCb,
+    })
   })
   describe('basic', function(){
     describe('success', function(){

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@ var helpers = require('./helpers')
 var assert = helpers.assert
 var makeHtml = helpers.makeHtml
 var RemoteForm = require('../index')
-var bean = require('bean')
+var event = require('compose-event')
 var request = require('superagent')
 var sinon = require('sinon')
 
@@ -11,17 +11,17 @@ describe('RemoteForm', function(){
     this.formEl = makeHtml(function(){/*
       <form data-remote="true"></form>
     */})
-    this.remoteForm = new RemoteForm({el: this.formEl})
+    //this.remoteForm = new RemoteForm({el: this.formEl})
     
     this.beforeSendCb = sinon.spy()
     this.successCb = sinon.spy()
     this.errorCb = sinon.spy()
     this.completeCb = sinon.spy()
     
-    bean.on(this.formEl, 'ajax:beforeSend', this.beforeSendCb)
-    bean.on(this.formEl, 'ajax:success', this.successCb)
-    bean.on(this.formEl, 'ajax:error', this.errorCb)
-    bean.on(this.formEl, 'ajax:complete', this.completeCb)
+    event.on(this.formEl, 'ajax:beforeSend', this.beforeSendCb)
+    event.on(this.formEl, 'ajax:success', this.successCb)
+    event.on(this.formEl, 'ajax:error', this.errorCb)
+    event.on(this.formEl, 'ajax:complete', this.completeCb)
     
     document.body.appendChild(this.formEl)
   })
@@ -36,8 +36,8 @@ describe('RemoteForm', function(){
         request.Request.prototype.end.restore()
       })
       beforeEach(function(done){
-        bean.one(this.formEl, 'ajax:complete', function(){done()})
-        bean.fire(this.formEl, 'submit')
+        event.one(this.formEl, 'ajax:complete', function(){done()})
+        event.fire(this.formEl, 'submit')
       })
 
       it('fires one ajax:beforeSend event', function(){
@@ -65,8 +65,8 @@ describe('RemoteForm', function(){
         request.Request.prototype.end.restore()
       })
       beforeEach(function(done){
-        bean.one(this.formEl, 'ajax:complete', function(){done()})
-        bean.fire(this.formEl, 'submit')
+        event.one(this.formEl, 'ajax:complete', function(){done()})
+        event.fire(this.formEl, 'submit')
       })
       it('fires zero ajax:success event', function(){
         assert.strictEqual(this.successCb.callCount, 0)
@@ -90,8 +90,8 @@ describe('RemoteForm', function(){
         request.Request.prototype.end.restore()
       })
       beforeEach(function(done){
-        bean.one(this.formEl, 'ajax:complete', function(){done()})
-        bean.fire(this.formEl, 'submit')
+        event.one(this.formEl, 'ajax:complete', function(){done()})
+        event.fire(this.formEl, 'submit')
       })
       it('fires zero ajax:success event', function(){
         assert.strictEqual(this.successCb.callCount, 0)
@@ -117,8 +117,8 @@ describe('RemoteForm', function(){
       })
       beforeEach(function(done){
         this.formEl.dataset.method = "delete"
-        bean.one(this.formEl, 'ajax:complete', function(){done()})
-        bean.fire(this.formEl, 'submit')
+        event.one(this.formEl, 'ajax:complete', function(){done()})
+        event.fire(this.formEl, 'submit')
       })
       it('fires one ajax:beforeSend event', function(){
         assert.strictEqual(this.beforeSendCb.callCount, 1)
@@ -132,9 +132,9 @@ describe('RemoteForm', function(){
     })
   })
   afterEach(function(){
-    bean.off(this.formEl, 'ajax:beforeSend', this.beforeSendCb)
-    bean.off(this.formEl, 'ajax:success', this.successCb)
-    bean.off(this.formEl, 'ajax:error', this.errorCb)
-    bean.off(this.formEl, 'ajax:complete', this.completeCb)
+    event.off(this.formEl, 'ajax:beforeSend', this.beforeSendCb)
+    event.off(this.formEl, 'ajax:success', this.successCb)
+    event.off(this.formEl, 'ajax:error', this.errorCb)
+    event.off(this.formEl, 'ajax:complete', this.completeCb)
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,6 @@ describe('RemoteForm', function(){
     this.formEl = makeHtml(function(){/*
       <form data-remote="true"></form>
     */})
-    //this.remoteForm = new RemoteForm({el: this.formEl})
     
     this.beforeSendCb = sinon.spy()
     this.successCb = sinon.spy()
@@ -24,6 +23,7 @@ describe('RemoteForm', function(){
     event.on(this.formEl, 'ajax:complete', this.completeCb)
     
     document.body.appendChild(this.formEl)
+    event.fire(document, 'DOMContentLoaded')
   })
   describe('basic', function(){
     describe('success', function(){
@@ -55,18 +55,16 @@ describe('RemoteForm', function(){
     })
 
     describe('error (unreachable server)', function(){
-      beforeEach(function(){
+      beforeEach(function(done){
         sinon.stub(request.Request.prototype, 'end', function(callback){
           this.xhr = {}
           callback(new Error('Fake error'))
         })
+        event.one(this.formEl, 'ajax:complete', function(){done()})
+        event.fire(this.formEl, 'submit')
       })
       afterEach(function(){
         request.Request.prototype.end.restore()
-      })
-      beforeEach(function(done){
-        event.one(this.formEl, 'ajax:complete', function(){done()})
-        event.fire(this.formEl, 'submit')
       })
       it('fires zero ajax:success event', function(){
         assert.strictEqual(this.successCb.callCount, 0)


### PR DESCRIPTION
We don't really need wagon for event delegation. Also this system should automatically register itself and require effectively zero bootstrap glue to get it working. This PR removes the need to register forms on page loads, and rather than using classes, it uses event registration and binding.
